### PR TITLE
:bug: Fixed checkboxes not working

### DIFF
--- a/Universal-DDS-Exporter.py
+++ b/Universal-DDS-Exporter.py
@@ -412,12 +412,12 @@ class UniversalDDSPlugin:
 
     # Handle export DDS files checkbox change
     def checkbox_export_change(self, state):
-        self.export = state == Qt.Checked
+        self.export = state == Qt.Checked.value
         self.save_config()
 
     # Handle overwrite DDS files checkbox change
     def checkbox_overwrite_change(self, state):
-        self.overwrite = state == Qt.Checked
+        self.overwrite = state == Qt.Checked.value
         self.save_config()
 
     # Save the current plugin configuration to the ini file


### PR DESCRIPTION
# Description
No matter if the checkboxes are checked or not, they never set their corresponding value in the .ini file to true/false. Effectively rendering the entire plug-in inert as it would never convert any files whatsoever.
## Fix
The culprit was a faulty access to the enum comparing its attribute instead of its value, which caused it to never become true no matter the actual input.
## Version
This fix was tested to work in Substance Painter v10.1.0 build 3963